### PR TITLE
Chore/umd build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 lib
+dist
 *.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ We also have a standalone build, which you simply can drop in via a `<script/>` 
   <script src="google-map-bounds-limit.js"></script>
 ```
 
-The `limitMap()` function is set on the `window` object. The `lib/` directory contains the umd-build.
+The `limitMap()` function is set on the `window` object. The `dist/` directory contains the umd-build.
+
 ## How to use
 
 ```js

--- a/README.md
+++ b/README.md
@@ -4,9 +4,21 @@ This module limits the map movement and zooming functionality of a provided goog
 
 ## Installation
 
+### npm
+
 ```sh
 npm install google-map-bounds-limit
 ```
+
+### UMD
+
+We also have a standalone build, which you simply can drop in via a `<script/>` tag:
+
+```html
+  <script src="google-map-bounds-limit.js"></script>
+```
+
+The `limitMap()` function is set on the `window` object. The `lib/` directory contains the umd-build.
 ## How to use
 
 ```js

--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src --out-dir lib",
+    "build:umd": "browserify --standalone limitMap src/index.js > lib/google-map-bounds-limit.js",
     "clean": "rm -rf lib && mkdir lib",
-    "prepublish": "npm run clean && npm run build"
+    "prepublish": "npm run clean && npm run build && npm run build:umd"
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   },
   "author": "",
   "license": "MIT",
@@ -14,6 +20,7 @@
     "babel-cli": "^6.10.1",
     "babel-eslint": "^6.1.0",
     "babel-preset-es2015": "^6.9.0",
+    "babelify": "^7.3.0",
     "browserify": "^13.0.1",
     "eslint": "^2.13.1"
   },

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.3",
   "description": "",
   "main": "lib/index.js",
+  "files": "dist",
   "scripts": {
-    "build": "babel src --out-dir lib",
-    "build:umd": "browserify --standalone limitMap src/index.js > lib/google-map-bounds-limit.js",
-    "clean": "rm -rf lib && mkdir lib",
+    "build": "babel src --out-dir lib && npm run build:umd",
+    "build:umd": "browserify --standalone limitMap src/index.js > dist/google-map-bounds-limit.js",
+    "clean": "rm -rf lib dist && mkdir lib dist",
     "prepublish": "npm run clean && npm run build && npm run build:umd"
   },
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-cli": "^6.10.1",
     "babel-eslint": "^6.1.0",
     "babel-preset-es2015": "^6.9.0",
+    "browserify": "^13.0.1",
     "eslint": "^2.13.1"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -142,3 +142,6 @@ export default function limitMap(map, maxBounds) {
   // call this once, because the next zoom level might already be too low
   limitMapMinZoom(map);
 }
+
+// for standalone build
+module.exports = limitMap;


### PR DESCRIPTION
- Generates a build which can be used in the browser without further bundling
- Will set `window.limitMap`
